### PR TITLE
fix: add prefix "autoware_" to gnss_poser

### DIFF
--- a/single_lidar_sensor_kit_launch/package.xml
+++ b/single_lidar_sensor_kit_launch/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <exec_depend>single_lidar_common_launch</exec_depend>
-  <exec_depend>gnss_poser</exec_depend>
+  <exec_depend>autoware_gnss_poser</exec_depend>
   <exec_depend>tamagawa_imu_driver</exec_depend>
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>ublox_gps</exec_depend>


### PR DESCRIPTION
Related to

* https://github.com/autowarefoundation/autoware.universe/pull/8323


Fix the following error.

```
+ rosdep install -y --from-paths src --ignore-src --rosdistro humble
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
single_lidar_sensor_kit_launch: Cannot locate rosdep definition for [gnss_poser]
```
