### PR TITLE
fix(single_lidar_sensor_kit_launch): add autoware prefix to vehicle_velocity_converter

### DIFF
--- a/single_lidar_sensor_kit_launch/launch/sensing.launch.xml
+++ b/single_lidar_sensor_kit_launch/launch/sensing.launch.xml
@@ -13,7 +13,7 @@
     </include>
 
     <!-- Vehicle Velocity Converter  -->
-    <include file="$(find-pkg-share vehicle_velocity_converter)/launch/vehicle_velocity_converter.launch.xml">
+    <include file="$(find-pkg-share autoware_vehicle_velocity_converter)/launch/vehicle_velocity_converter.launch.xml">
       <arg name="input_vehicle_velocity_topic" value="/vehicle/status/velocity_status"/>
       <arg name="output_twist_with_covariance" value="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
     </include>

--- a/single_lidar_sensor_kit_launch/package.xml
+++ b/single_lidar_sensor_kit_launch/package.xml
@@ -11,6 +11,7 @@
 
   <exec_depend>single_lidar_common_launch</exec_depend>
   <exec_depend>autoware_gnss_poser</exec_depend>
+  <exec_depend>autoware_vehicle_velocity_converter</exec_depend>
   <exec_depend>tamagawa_imu_driver</exec_depend>
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>ublox_gps</exec_depend>


### PR DESCRIPTION
## Description
This PR will add the autoware prefix to `vehicle_velocity_converter` due to the changes in https://github.com/autowarefoundation/autoware.universe/pull/8967 .

This should merge with https://github.com/autowarefoundation/autoware.universe/pull/8967

