### PR TITLE
chore: bump version to 0.39.0

### DIFF
--- a/single_lidar_common_launch/CHANGELOG.rst
+++ b/single_lidar_common_launch/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package single_lidar_common_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.39.0 (2024-12-12)
+-------------------
 * feature(single_lidar_common_launch): load from parameter (`#3 <https://github.com/autowarefoundation/single_lidar_sensor_kit_launch/issues/3>`_)
 * chore(nebula_node_container): make launcher work with Nebula v0.2.0 (`#2 <https://github.com/autowarefoundation/single_lidar_sensor_kit_launch/issues/2>`_)
 * feat(single_lidar_sensor_kit): add single_lidar_sensor_kit

--- a/single_lidar_common_launch/CHANGELOG.rst
+++ b/single_lidar_common_launch/CHANGELOG.rst
@@ -1,0 +1,10 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package single_lidar_common_launch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* feature(single_lidar_common_launch): load from parameter (`#3 <https://github.com/autowarefoundation/single_lidar_sensor_kit_launch/issues/3>`_)
+* chore(nebula_node_container): make launcher work with Nebula v0.2.0 (`#2 <https://github.com/autowarefoundation/single_lidar_sensor_kit_launch/issues/2>`_)
+* feat(single_lidar_sensor_kit): add single_lidar_sensor_kit
+* Contributors: Max Schmeller, Yi-Hsiang Fang (Vivid), beginningfan

--- a/single_lidar_common_launch/package.xml
+++ b/single_lidar_common_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>single_lidar_common_launch</name>
-  <version>0.1.0</version>
+  <version>0.39.0</version>
   <description>The single_lidar_common_launch package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/single_lidar_sensor_kit_description/CHANGELOG.rst
+++ b/single_lidar_sensor_kit_description/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package single_lidar_sensor_kit_description
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* feat(single_lidar_sensor_kit): add single_lidar_sensor_kit
+* Contributors: beginningfan

--- a/single_lidar_sensor_kit_description/CHANGELOG.rst
+++ b/single_lidar_sensor_kit_description/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package single_lidar_sensor_kit_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.39.0 (2024-12-12)
+-------------------
 * feat(single_lidar_sensor_kit): add single_lidar_sensor_kit
 * Contributors: beginningfan

--- a/single_lidar_sensor_kit_description/package.xml
+++ b/single_lidar_sensor_kit_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>single_lidar_sensor_kit_description</name>
-  <version>0.1.0</version>
+  <version>0.39.0</version>
   <description>The single_lidar_sensor_kit_description package</description>
   <maintainer email="beginning.fan@autocore.ai">beginning.fan</maintainer>
   <license>Apache License 2.0</license>

--- a/single_lidar_sensor_kit_launch/CHANGELOG.rst
+++ b/single_lidar_sensor_kit_launch/CHANGELOG.rst
@@ -1,0 +1,10 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package single_lidar_sensor_kit_launch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* fix: add prefix "autoware\_" to gnss_poser
+* Added prefix "autoware\_" to gnss_poser
+* feat(single_lidar_sensor_kit): add single_lidar_sensor_kit
+* Contributors: M. Fatih Cırıt, Shintaro Sakoda, beginningfan

--- a/single_lidar_sensor_kit_launch/CHANGELOG.rst
+++ b/single_lidar_sensor_kit_launch/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package single_lidar_sensor_kit_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.39.0 (2024-12-12)
+-------------------
 * fix: add prefix "autoware\_" to gnss_poser
 * Added prefix "autoware\_" to gnss_poser
 * feat(single_lidar_sensor_kit): add single_lidar_sensor_kit

--- a/single_lidar_sensor_kit_launch/package.xml
+++ b/single_lidar_sensor_kit_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>single_lidar_sensor_kit_launch</name>
-  <version>0.1.0</version>
+  <version>0.39.0</version>
   <description>The single_lidar_sensor_kit_launch package</description>
   <maintainer email="beginning.fan@autocore.ai">beginning.fan</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
## Description

This makes the release for 0.39.0 which is compatible with autoware.universe 0.39.0

## Related Issue
https://github.com/autowarefoundation/autoware/issues/5544