### PR TITLE
feat: rename velodyne_monitor with autoware_velodyne_monitor

### DIFF
--- a/single_lidar_common_launch/launch/velodyne_VLP16.launch.xml
+++ b/single_lidar_common_launch/launch/velodyne_VLP16.launch.xml
@@ -35,7 +35,7 @@
   </include>
 
   <!-- Velodyne Monitor -->
-  <include file="$(find-pkg-share velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
+  <include file="$(find-pkg-share autoware_velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
     <arg name="ip_address" value="$(var sensor_ip)"/>
   </include>
 </launch>

--- a/single_lidar_common_launch/launch/velodyne_VLS128.launch.xml
+++ b/single_lidar_common_launch/launch/velodyne_VLS128.launch.xml
@@ -35,7 +35,7 @@
   </include>
 
   <!-- Velodyne Monitor -->
-  <include file="$(find-pkg-share velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
+  <include file="$(find-pkg-share autoware_velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
     <arg name="ip_address" value="$(var sensor_ip)"/>
   </include>
 </launch>

--- a/single_lidar_common_launch/package.xml
+++ b/single_lidar_common_launch/package.xml
@@ -10,8 +10,8 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <exec_depend>autoware_velodyne_monitor</exec_depend>
   <exec_depend>nebula_sensor_driver</exec_depend>
-  <exec_depend>velodyne_monitor</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>


### PR DESCRIPTION
## Description
This PR adds autoware_ prefix to velodyne_monitor package.
For the details, please refer to https://github.com/autowarefoundation/autoware.universe/pull/9976.

## How was this PR tested?

run autoware with sample_sensor_kit sensor_model
`ros2 launch autoware_launch autoware.launch.xml map_path:=$HOME/autoware_map/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=single_lidar_sensor_kit`

## Notes for reviewers

This must be merged with https://github.com/autowarefoundation/autoware.universe/pull/9976
