### PR TITLE
refactor(single_lidar_sensor_kit_launch): remove reference to tamagawa_imu_driver

### DIFF
--- a/single_lidar_sensor_kit_launch/package.xml
+++ b/single_lidar_sensor_kit_launch/package.xml
@@ -12,7 +12,6 @@
   <exec_depend>single_lidar_common_launch</exec_depend>
   <exec_depend>autoware_gnss_poser</exec_depend>
   <exec_depend>autoware_vehicle_velocity_converter</exec_depend>
-  <exec_depend>tamagawa_imu_driver</exec_depend>
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>ublox_gps</exec_depend>
   <exec_depend>usb_cam</exec_depend>


### PR DESCRIPTION
This PR removes the `tamagawa_imu_driver` package from the dependency list.

See https://github.com/autowarefoundation/autoware/issues/5804 and https://github.com/autowarefoundation/autoware/issues/3366#issuecomment-2664445289